### PR TITLE
Ignore administrators

### DIFF
--- a/drip.php
+++ b/drip.php
@@ -151,7 +151,8 @@ class WP_Drip {
 	 */
 	public function tracking_code() {
 		// Check if the ID is set and is an integer
-		if ( ! $this->get_option( 'is_disabled' ) ) {
+		$bDisplayCodeForUser = !( $this->get_option( 'ignore_administrators' ) && is_user_logged_in() && current_user_can( 'manage_options' ) );
+		if ( ! $this->get_option( 'is_disabled' ) && $bDisplayCodeForUser ) {
 			if ( $this->get_option( 'account_id' ) ) { 
 				$account_id = $this->get_option( 'account_id' );
 				include( WP_DRIP_DIRNAME . "/views/tracking-code.php" );
@@ -237,6 +238,7 @@ class WP_Drip {
 		add_settings_section( 'drip_code_settings', 'Tracking Code', array( $this, 'admin_section_code_settings' ), $this->namespace );
 		add_settings_field( 'drip_account_id', 'Account ID', array( $this, 'admin_option_account_id' ), $this->namespace, 'drip_code_settings' );
 		add_settings_field( 'drip_is_disabled', 'Visibility', array( $this, 'admin_option_is_disabled' ), $this->namespace, 'drip_code_settings' );
+		add_settings_field( 'drip_ignore_administrators', 'Ignore Administrators', array( $this, 'admin_option_ignore_administrators' ), $this->namespace, 'drip_code_settings' );
 	}
 	
 	/**
@@ -260,13 +262,20 @@ class WP_Drip {
 				add_settings_error( 'account_id', $this->namespace . '_account_id_error', "Please enter a valid account ID", 'error' );
 			}
 		}
-		
-    if ( isset( $input['is_disabled'] ) ) {
-      $options['is_disabled'] = $input['is_disabled'] == "1";
-    } else {
-      $options['is_disabled'] = false;
-    }
-    
+
+		if ( isset( $input['is_disabled'] ) ) {
+			$options['is_disabled'] = $input['is_disabled'] == "1";
+		} else {
+			$options['is_disabled'] = false;
+		}
+
+		if ( isset( $input['ignore_administrators'] ) ) {
+			$options['ignore_administrators'] = ( $input['ignore_administrators'] == "1" );
+		}
+		else {
+			$options['ignore_administrators'] = false;
+		}
+
 		return $options;
 	}
 	
@@ -284,6 +293,15 @@ class WP_Drip {
 		echo "<label><input type='checkbox' name='drip_options[is_disabled]' value='1' " . 
 			checked( 1, $this->get_option( 'is_disabled' ), false ) . " /> " .
 			"Disable tracking code on all pages</label>";
+	}
+
+	/**
+	 * Output the input for the account ID option
+	 */
+	public function admin_option_ignore_administrators() {
+		echo '<label><input type="checkbox" name="drip_options[ignore_administrators]" value="1" ' .
+			checked( 1, $this->get_option( 'ignore_administrators' ), false ) . ' /> ' .
+			"Ignore Logged-In Administrators</label>";
 	}
 	
 	/** 

--- a/drip.php
+++ b/drip.php
@@ -89,23 +89,23 @@ class WP_Drip {
 	 */
 	private function _add_hooks() {
 		// Activation and deactivation
-		register_activation_hook( __FILE__, array( &$this, 'activate' ) );
-		register_deactivation_hook( __FILE__, array( &$this, 'deactivate' ) );
+		register_activation_hook( __FILE__, array( $this, 'activate' ) );
+		register_deactivation_hook( __FILE__, array( $this, 'deactivate' ) );
 		
 		// Options page for configuration
-		add_action( 'admin_menu', array( &$this, 'admin_menu' ) );
+		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 
 		// Register admin settings
-		add_action( 'admin_init', array( &$this, 'admin_register_settings' ) );
+		add_action( 'admin_init', array( $this, 'admin_register_settings' ) );
 		
 		// Register activation redirect
-		add_action( 'admin_init', array( &$this, 'do_activation_redirect' ) );
+		add_action( 'admin_init', array( $this, 'do_activation_redirect' ) );
 		
 		// Add settings link on plugins page
-		add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( &$this, 'plugin_action_links' ) );
+		add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'plugin_action_links' ) );
 
 		// Place tracking code in the footer
-		add_action( 'wp_footer', array( &$this, 'tracking_code' ) );
+		add_action( 'wp_footer', array( $this, 'tracking_code' ) );
 	}
 	
 	/**
@@ -186,10 +186,10 @@ class WP_Drip {
 	 * @uses add_options_page()
 	 */
 	public function admin_menu() {
-		$page_hook = add_options_page( 'Drip Settings', $this->friendly_name, 'manage_options', $this->namespace, array( &$this, 'admin_options_page' ) );
+		$page_hook = add_options_page( 'Drip Settings', $this->friendly_name, 'manage_options', $this->namespace, array( $this, 'admin_options_page' ) );
 		
 		// Add admin scripts and styles
-		add_action( 'admin_enqueue_scripts', array( &$this, 'admin_enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 	}
 	
 	/**
@@ -233,10 +233,10 @@ class WP_Drip {
 	 * @uses add_settings_field()
 	 */
 	public function admin_register_settings() {
-		register_setting( $this->options_name, $this->options_name, array( &$this, 'validate_settings' ) );
-		add_settings_section( 'drip_code_settings', 'Tracking Code', array( &$this, 'admin_section_code_settings' ), $this->namespace );
-		add_settings_field( 'drip_account_id', 'Account ID', array( &$this, 'admin_option_account_id' ), $this->namespace, 'drip_code_settings' );
-		add_settings_field( 'drip_is_disabled', 'Visibility', array( &$this, 'admin_option_is_disabled' ), $this->namespace, 'drip_code_settings' );
+		register_setting( $this->options_name, $this->options_name, array( $this, 'validate_settings' ) );
+		add_settings_section( 'drip_code_settings', 'Tracking Code', array( $this, 'admin_section_code_settings' ), $this->namespace );
+		add_settings_field( 'drip_account_id', 'Account ID', array( $this, 'admin_option_account_id' ), $this->namespace, 'drip_code_settings' );
+		add_settings_field( 'drip_is_disabled', 'Visibility', array( $this, 'admin_option_is_disabled' ), $this->namespace, 'drip_code_settings' );
 	}
 	
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -63,5 +63,9 @@ to get started!
 
 == Changelog ==
 
+= 1.0.1 =
+
+* Added option to ignore logged-in administrators so as to not impact form display statistics
+
 = 1.0.0 =
 * Initial release.


### PR DESCRIPTION
There are 2 main changes:
- removed possible warnings for deprecated PHP pass-by-reference. i.e. _&$variable_
- Adds a simple checkbox option that will allow you to ignore logged-in administrators. This prevents any impact or skewing of form display statistics as an administrator browses their own site.
